### PR TITLE
Pymtforward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,11 @@ node_modules
 payproc.conf
 payproc.chris.conf
 payproc.btc.chris.conf
+
+# vi tmp files
+*.swp
+*~
+*.swo
+
+# Database files
+payproc.db

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Install dependencies**
 
 ```
-npm install blocktrail-sdk
+npm install
 ```
 
 **Copy the payproc.sample.conf file to payproc.conf and edit it.**

--- a/README.md
+++ b/README.md
@@ -20,12 +20,18 @@ $ vi payproc.conf
 		"WALLET_NAME": "the wallet name",
 		"WALLET_PASSWORD": "the wallet password",
 		"USE_TESTNET": true,
-		"PORT": 11306
+		"PORT": 11306,
+		"DB_FILE": "payproc.db",
+		"FORWARD_BAL_THRESHOLD": 143900,
+		"FWD_PAY_DELAY": 600000
 	}
 }
 ```
 
-Adjust the settings to match your Blocktrail information and the server's port number.
+* Adjust the settings to match your Blocktrail information and the server's port number.
+* The configuration, FORWARD_BAL_THRESHOLD, is in Satoshis (1 BTC = 100,000,000 Satoshis).
+* FWD_PAY_DELAY is number of milliseconds to between payment forwarding scans.
+
 
 **Run the server**
 
@@ -35,12 +41,12 @@ node payproc.js
 
 ## Usage
 
-### /payproc/api/receive
+### /payproc/receive
 
-To generate a receive address for payments, use /payproc/api/receive.
+To generate a receive address for payments, use /payproc/receive.
 
 ```
-$ curl "http://localhost:11306/payproc/api/receive?address=2N4ajxiM1xHc83mehV2LTXk2Z65TAfc9MhX&amount=0.432"
+$ curl "http://localhost:11306/payproc/receive?address=2N4ajxiM1xHc83mehV2LTXk2Z65TAfc9MhX&amount=0.432"
 {"input_address":"2N6dDdHGx24ss6AoAqjx8gnc2JQpETe1mBp"}
 ```
 
@@ -54,19 +60,21 @@ Return:
 
 **temporary address** _The temporary address that can be shown to the buyer._
 
-### /payproc/api/getreceivedbyaddress
+### /payproc/getreceivedbyaddress
 
 To check the total amount of the unconfirmed balance of the given BTC address:
 
 ```
-$ curl "http://localhost:11306/payproc/api/getreceivedbyaddress/2N4ajxiM1xHc83mehV2LTXk2Z65TAfc9MhX"
+$ curl "http://localhost:11306/payproc/getreceivedbyaddress/2N4ajxiM1xHc83mehV2LTXk2Z65TAfc9MhX"
 0.00000000
 ```
 
 Path Parameter:
 
-/payproc/api/getreceivedbyaddress/**[BTC ADDRESS]**  _The temporary payment address to monitor._
+/payproc/getreceivedbyaddress/**[BTC ADDRESS]**  _The temporary payment address to monitor._
 
 Return:
 
 The unconfirmed balance in BTC.
+
+###

--- a/README.md
+++ b/README.md
@@ -77,4 +77,16 @@ Return:
 
 The unconfirmed balance in BTC.
 
-###
+### /payproc/ping
+
+To check whether the service is alive or not.
+
+```
+$ curl "http://localhost:11306/payproc/ping"
+ALIVE
+```
+
+Return:
+
+**ALIVE** Payproc is alive
+

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/dloa/paywall-web#readme",
   "dependencies": {
-    "blocktrail-sdk": "^2.0.0"
+    "blocktrail-sdk": "^2.0.0",
+    "sqlite3": "^3.1.4"
   }
 }

--- a/payproc.sample.conf
+++ b/payproc.sample.conf
@@ -5,6 +5,9 @@
 		"WALLET_NAME": "the wallet name",
 		"WALLET_PASSWORD": "the wallet password",
 		"USE_TESTNET": true,
-		"PORT": 11306
+		"PORT": 11306,
+		"DB_FILE": "payproc.db",
+		"FORWARD_BAL_THRESHOLD": 143900,
+		"FWD_PAY_DELAY": 60000
 	}
 }


### PR DESCRIPTION
Payment forwarding without payment address rotation. A local sqlite3 database keeps track of a payable amount for each payment address that is captured with the /payproc/receive endpoint. Some properties were added to the configuration file. Notably, there are settings for the delay between payment forwarding scans and the payment balance threshold that triggers forwarding.

This implementation allows the Blocktrail wallet to select the inputs for the payment instead of forcing inputs to come from the payment addresses used to receive micropayments from the browser. Proper sweeping will come later.
