### PR TITLE
Return early on null client

### DIFF
--- a/payproc.js
+++ b/payproc.js
@@ -163,6 +163,7 @@ function payWalletBalance(balanceCb) {
 function addressBalance(address, balanceCb) {
 	if (client === undefined) {
 		setTimeout(addressBalance(address, balanceCb), 250);
+		return;
 	}
 
 	client.address(address).then(function(address) {


### PR DESCRIPTION
Simple fix to avoid using a null client by returning early from addressBalance after scheduling a later call via setTimeout. The branch can be deleted on merge. Thanks.